### PR TITLE
Fixed 'Surivival' typo

### DIFF
--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/KaboomMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/KaboomMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * Copyright Â© 2014 - 2016 | Wurst-Imperium | All rights reserved.
  * 
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -63,7 +63,7 @@ public class KaboomMod extends Mod implements UpdateListener
 	{
 		if(mc.thePlayer.capabilities.isCreativeMode)
 		{
-			wurst.chat.error("Surivival mode only.");
+			wurst.chat.error("Survival mode only.");
 			setEnabled(false);
 			return;
 		}


### PR DESCRIPTION
I only fixed this typo, sorry if this commit is too small.
