### PR TITLE
Added capability to restore disabled mods after panic

### DIFF
--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
@@ -7,6 +7,7 @@
  */
 package tk.wurst_client.mods;
 
+import java.util.ArrayList;
 import tk.wurst_client.events.listeners.UpdateListener;
 import tk.wurst_client.mods.Mod.Category;
 import tk.wurst_client.mods.Mod.Info;

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
@@ -32,8 +32,10 @@ public class PanicMod extends Mod implements UpdateListener
 	{
 		for(Mod mod : wurst.mods.getAllMods())
 			if(mod.getCategory() != Category.HIDDEN && mod.isEnabled())
+			{
 				mod.setEnabled(false);
 				panicedMods.add(mod);
+			}
 	}
 	
 	@Override

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2016 | Wurst-Imperium | A few rights reserved.
+ * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
  * 
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -25,7 +25,7 @@ public class PanicMod extends Mod implements UpdateListener
 		wurst.events.add(UpdateListener.class, this);
 	}
 	
-	private Mod panicedMods[] = [];
+	private ArrayList panicedMods[] = new ArrayList();
 	
 	@Override
 	public void onUpdate()
@@ -41,11 +41,11 @@ public class PanicMod extends Mod implements UpdateListener
 	@Override
 	public void onDisable()
 	{
-		for(Mod mod : wurst.mods.getAllMods())
-		{//I like curly braces :}
+		for(Mod mod : panicedMods)
+		{
 			mod.setEnabled(true);
-			panicedMods.add(mod);
 		}
+		panicedMods.clear();
 		wurst.events.remove(UpdateListener.class, this);
 	}
 }

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * Copyright Â© 2014 - 2016 | Wurst-Imperium | A few rights reserved.
  * 
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -25,17 +25,25 @@ public class PanicMod extends Mod implements UpdateListener
 		wurst.events.add(UpdateListener.class, this);
 	}
 	
+	private Mod panicedMods[] = [];
+	
 	@Override
 	public void onUpdate()
 	{
 		for(Mod mod : wurst.mods.getAllMods())
 			if(mod.getCategory() != Category.HIDDEN && mod.isEnabled())
 				mod.setEnabled(false);
+				panicedMods.add(mod);
 	}
 	
 	@Override
 	public void onDisable()
 	{
+		for(Mod mod : wurst.mods.getAllMods())
+		{//I like curly braces :}
+			mod.setEnabled(true);
+			panicedMods.add(mod);
+		}
 		wurst.events.remove(UpdateListener.class, this);
 	}
 }

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/PanicMod.java
@@ -26,7 +26,7 @@ public class PanicMod extends Mod implements UpdateListener
 		wurst.events.add(UpdateListener.class, this);
 	}
 	
-	private ArrayList panicedMods[] = new ArrayList();
+	List<Mod> panicedMods = new ArrayList<>();
 	
 	@Override
 	public void onUpdate()


### PR DESCRIPTION
I am an avid user of wurst... (SHHHH) :D , and of course, the panic key can be incredibly useful (I am proud to say that it has prevented me from getting banned on a good number of servers). I have a certain set of mods that I like to use, so when I panic I have to go and put up all those hacks again. The panic key should toggle hacks so you can simply re-enable your disabled mods. I just threw this together really quickly, no need to test, it is so small. 

Thank you for considering this pull request!
