### PR TITLE
Added MassTell Mod

### DIFF
--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
@@ -6,8 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
  /*
- * Made by dGRAMOP for WURST!!!
- * 
  * Use case: 
  * Regular chat is disabled/you are muted
  * You want to make it [message] seem less like a broadcast

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
@@ -14,8 +14,6 @@ import java.util.Random;
 
 import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.util.StringUtils;
-import tk.wurst_client.events.ChatInputEvent;
-import tk.wurst_client.events.listeners.ChatInputListener;
 import tk.wurst_client.events.listeners.UpdateListener;
 import tk.wurst_client.mods.Mod.Bypasses;
 import tk.wurst_client.mods.Mod.Category;
@@ -28,8 +26,7 @@ import tk.wurst_client.mods.Mod.Info;
 	tags = "mass tell",
 	help = "Mods/MassTell")
 @Bypasses
-public class MassTell extends Mod implements UpdateListener,
-	ChatInputListener
+public class MassTell extends Mod implements UpdateListener
 {
 	private float speed = 1F;
 	private int i;

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ /*
+ * Made by dGRAMOP for WURST!!!
+ * 
+ * Use case: 
+ * Regular chat is disabled/you are muted
+ * You want to make it [message] seem less like a broadcast
+ */
+package tk.wurst_client.mods;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Random;
+
+import net.minecraft.client.network.NetworkPlayerInfo;
+import net.minecraft.util.StringUtils;
+import tk.wurst_client.events.ChatInputEvent;
+import tk.wurst_client.events.listeners.ChatInputListener;
+import tk.wurst_client.events.listeners.UpdateListener;
+import tk.wurst_client.mods.Mod.Bypasses;
+import tk.wurst_client.mods.Mod.Category;
+import tk.wurst_client.mods.Mod.Info;
+
+@Info(category = Category.CHAT,
+	description = "Sends a private message to all players.\n"
+		+ "Useful if: \nRegular chat is disabled/you are muted \nYou want to make your message seem less like a broadcast ",
+	name = "MassTell",
+	tags = "mass tell",
+	help = "Mods/MassTell")
+@Bypasses
+public class MassTellMod extends Mod implements UpdateListener,
+	ChatInputListener
+{
+	private float speed = 1F;
+	private int i;
+	private ArrayList<String> players;
+	private Random random = new Random();
+	
+	@Override
+	public void onEnable()
+	{
+		i = 0;
+		Iterator itr = mc.getNetHandler().getPlayerInfoMap().iterator();
+		players = new ArrayList<String>();
+		while(itr.hasNext())
+			players.add(StringUtils.stripControlCodes(((NetworkPlayerInfo)itr
+				.next()).getPlayerNameForReal()));
+		Collections.shuffle(players, random);
+		wurst.events.add(ChatInputListener.class, this);
+		wurst.events.add(UpdateListener.class, this);
+	}
+	
+	@Override
+	public void onUpdate()
+	{
+		updateMS();
+		if(hasTimePassedS(speed))
+		{
+			String name = players.get(i);
+			if(!name.equals(mc.thePlayer.getName()))
+				mc.thePlayer.sendChatMessage("/tell " + name);
+			updateLastMS();
+			i++;
+			if(i >= players.size())
+				setEnabled(false);
+		}
+	}
+	
+	@Override
+	public void onDisable()
+	{
+		wurst.events.remove(ChatInputListener.class, this);
+		wurst.events.remove(UpdateListener.class, this);
+	}
+	
+	@Override
+	public void onReceivedMessage(ChatInputEvent event)
+	{
+		String message = event.getComponent().getUnformattedText();
+		if(message.startsWith("§c[§6Wurst§c]§f "))
+			return;
+		if(message.toLowerCase().contains("/help")
+			|| message.toLowerCase().contains("permission"))
+		{
+			event.cancel();
+			wurst.chat.message("§4§lERROR:§f This server doesn't have TPA.");
+			setEnabled(false);
+		}else if(message.toLowerCase().contains("accepted")
+			&& message.toLowerCase().contains("request")
+			|| message.toLowerCase().contains("akzeptiert")
+			&& message.toLowerCase().contains("anfrage"))
+		{
+			event.cancel();
+			wurst.chat.message("Someone accepted your TPA request. Stopping.");
+			setEnabled(false);
+		}
+	}
+}

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
@@ -35,7 +35,7 @@ import tk.wurst_client.mods.Mod.Info;
 	tags = "mass tell",
 	help = "Mods/MassTell")
 @Bypasses
-public class MassTellMod extends Mod implements UpdateListener,
+public class MassTell extends Mod implements UpdateListener,
 	ChatInputListener
 {
 	private float speed = 1F;

--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/MassTell.java
@@ -5,11 +5,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- /*
- * Use case: 
- * Regular chat is disabled/you are muted
- * You want to make it [message] seem less like a broadcast
- */
 package tk.wurst_client.mods;
 
 import java.util.ArrayList;
@@ -76,28 +71,5 @@ public class MassTell extends Mod implements UpdateListener,
 	{
 		wurst.events.remove(ChatInputListener.class, this);
 		wurst.events.remove(UpdateListener.class, this);
-	}
-	
-	@Override
-	public void onReceivedMessage(ChatInputEvent event)
-	{
-		String message = event.getComponent().getUnformattedText();
-		if(message.startsWith("§c[§6Wurst§c]§f "))
-			return;
-		if(message.toLowerCase().contains("/help")
-			|| message.toLowerCase().contains("permission"))
-		{
-			event.cancel();
-			wurst.chat.message("§4§lERROR:§f This server doesn't have TPA.");
-			setEnabled(false);
-		}else if(message.toLowerCase().contains("accepted")
-			&& message.toLowerCase().contains("request")
-			|| message.toLowerCase().contains("akzeptiert")
-			&& message.toLowerCase().contains("anfrage"))
-		{
-			event.cancel();
-			wurst.chat.message("Someone accepted your TPA request. Stopping.");
-			setEnabled(false);
-		}
 	}
 }


### PR DESCRIPTION
Supercedes #28 

Hello!

Thanks for reading over this! 
I just added a mod that individually PM's everyone on the server. Use case would be servers that block chat, but allow PM, or for making a broadcast that seems less like a broadcast. 

Why not /tell @a?
 ^- Many servers have @e @a @p etc. turned off. ;'(

Thanks,
Skype dhruv.gram
MC dgramop
