### PR TITLE
BoatFly Kick Fix

### DIFF
--- a/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/BoatFlyMod.java
+++ b/Wurst Client for MC 1.9.X/src/tk/wurst_client/mods/BoatFlyMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 | Alexander01998 | All rights reserved.
+ * Copyright Â© 2016 | Alexander01998 | All rights reserved.
  * 
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -31,8 +31,9 @@ public class BoatFlyMod extends Mod implements UpdateListener
 		if(!mc.thePlayer.isRiding())
 			return;
 		
+		// Might want to add a option for boats gliding down (motionY -0.035), but for now I will leave this as is.
 		mc.thePlayer.getRidingEntity().motionY =
-			mc.gameSettings.keyBindJump.pressed ? 0.3 : 0;
+			mc.gameSettings.keyBindJump.pressed ? 0.3 : -0.035;
 	}
 	
 	@Override


### PR DESCRIPTION
Prevents users from getting kicked while flying with a boat for "Flying is not enabled."
This only applies to servers with flying disabled in their server.properties, which by default it is disabled, if you make any entity glide down motionY -0.035 they will not be kicked whilst airborne.

You might want to add a option for this, but I recommend having it by default to have a easier user friendly experience.

@Alexander01998 

Simple commit, hope to see it added.
